### PR TITLE
Feature replace oss with minio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.4.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/alipay/autotuneservice/minio/IMinioClient.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/IMinioClient.java
@@ -1,0 +1,59 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.autotuneservice.minio;
+
+import io.minio.MinioClient;
+
+/**
+ * @author huangkaifei
+ * @version : IMinioClient.java, v 0.1 2022年11月09日 2:19 AM huangkaifei Exp $
+ */
+public interface IMinioClient {
+
+    /**
+     * Get Minio client
+     *
+     * @return MinioClient object
+     */
+    MinioClient getMinioClient();
+
+    /**
+     * Check whether the bucket exists
+     *
+     * @param bucket bucket name
+     * @return true - exist, false - not exist
+     */
+    Boolean checkBucketExists(String bucket);
+
+    /**
+     * Check whether the object exists in bucket
+     *
+     * @param bucket bucket name
+     * @param object object name
+     * @return true - exist, false - not exist
+     */
+    Boolean checkObjectExists(String bucket, String object);
+
+    /**
+     * Upload file to minio server
+     *
+     * @param bucket bucket name
+     * @param filePath file path
+     * @param fileName file name
+     * @return MinioUploadFileResult object
+     */
+    MinioUploadFileResult uploadObject(String bucket, String filePath, String fileName);
+
+    /**
+     * Download object from minio server
+     * note: minio server will put the download file to downloadFilePath path.
+     *
+     * @param bucket bucket name
+     * @param object the object name stored in Minio server
+     * @param downloadFilePath the file path to put the download fiel
+     * @return
+     */
+    MinioDownloadObjectResult downloadObject(String bucket, String object, String downloadFilePath);
+}

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
@@ -1,0 +1,126 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.autotuneservice.minio;
+
+import com.alibaba.fastjson.JSON;
+import io.minio.BucketExistsArgs;
+import io.minio.DownloadObjectArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.ObjectWriteResponse;
+import io.minio.UploadObjectArgs;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @author huangkaifei
+ * @version : MinioClientImpl.java, v 0.1 2022年11月09日 2:25 AM huangkaifei Exp $
+ */
+@Slf4j
+@Component
+public class MinioClientImpl implements IMinioClient {
+
+    private static final String MINIO_SERVER     = "http://localhost:30087";
+    private static final String MINIO_ACCESS_KEY = "minioadmin";
+    private static final String MINIO_SECRET_KEY = "minioadmin";
+
+    private MinioClient minioClient = null;
+
+    @PostConstruct
+    public void initMinioClient() {
+        this.minioClient = getClient();
+    }
+
+    private MinioClient getClient() {
+        if (minioClient == null) {
+            return MinioClient.builder()
+                    .endpoint(MINIO_SERVER)
+                    .credentials(MINIO_ACCESS_KEY, MINIO_SECRET_KEY)
+                    .build();
+        }
+        return minioClient;
+    }
+
+    @Override
+    public MinioClient getMinioClient() {
+        return getClient();
+    }
+
+    @Override
+    public Boolean checkBucketExists(String bucket) {
+        try{
+            return getMinioClient().bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+        }catch (Exception e){
+            throw new RuntimeException("");
+        }
+    }
+
+    @Override
+    public Boolean checkObjectExists(String bucket, String object) {
+        try{
+            // TO BE SUPPORTED
+            return false;
+        }catch (Exception e){
+            throw new RuntimeException("");
+        }
+    }
+
+    @Override
+    public MinioUploadFileResult uploadObject(String bucket, String filePath, String fileName) {
+        try {
+            boolean found = getMinioClient().bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+            if (!checkBucketExists(bucket)) {
+                // Make a new bucket called 'asiatrip'.
+                log.info("bucket={} not exists, so will create it.", bucket);
+                minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+            }
+            ObjectWriteResponse response = minioClient.uploadObject(
+                    UploadObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(fileName)
+                            .filename(filePath)
+                            .build());
+            if (response == null) {
+                throw new UnsupportedOperationException("uploadObject failed.");
+            }
+            MinioUploadFileResult uploadFIleResult = MinioUploadFileResult.builder()
+                    .eTag(response.etag())
+                    .bucket(response.bucket())
+                    .object(response.object())
+                    .build();
+
+            log.info("uploadObject res={}", JSON.toJSONString(uploadFIleResult));
+            return uploadFIleResult;
+        } catch (Exception e) {
+            log.error("uploadObject occurs an error", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public MinioDownloadObjectResult downloadObject(String bucket, String object, String downloadFilePath) {
+        try {
+            DownloadObjectArgs build = DownloadObjectArgs.builder()
+                    .bucket(bucket)
+                    .filename(downloadFilePath)
+                    .object(object)
+                    .overwrite(true)
+                    .build();
+            getMinioClient().downloadObject(build);
+            log.info("download object={} successful.", object);
+            return MinioDownloadObjectResult.builder()
+                    .bucket(bucket)
+                    .object(object)
+                    .isObjectExists(true)
+                    .build();
+        }catch (Exception e){
+            log.error("downloadObject occurs an error.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
@@ -25,6 +25,7 @@ import javax.annotation.PostConstruct;
 public class MinioClientImpl implements IMinioClient {
 
     private static final String MINIO_API_SERVER = "http://localhost:30087";
+
     private static final String MINIO_ACCESS_KEY = "minioadmin";
     private static final String MINIO_SECRET_KEY = "minioadmin";
 

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioClientImpl.java
@@ -24,7 +24,7 @@ import javax.annotation.PostConstruct;
 @Component
 public class MinioClientImpl implements IMinioClient {
 
-    private static final String MINIO_SERVER     = "http://localhost:30087";
+    private static final String MINIO_API_SERVER = "http://localhost:30087";
     private static final String MINIO_ACCESS_KEY = "minioadmin";
     private static final String MINIO_SECRET_KEY = "minioadmin";
 
@@ -38,7 +38,7 @@ public class MinioClientImpl implements IMinioClient {
     private MinioClient getClient() {
         if (minioClient == null) {
             return MinioClient.builder()
-                    .endpoint(MINIO_SERVER)
+                    .endpoint(MINIO_API_SERVER)
                     .credentials(MINIO_ACCESS_KEY, MINIO_SECRET_KEY)
                     .build();
         }
@@ -52,19 +52,19 @@ public class MinioClientImpl implements IMinioClient {
 
     @Override
     public Boolean checkBucketExists(String bucket) {
-        try{
+        try {
             return getMinioClient().bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
-        }catch (Exception e){
+        } catch (Exception e) {
             throw new RuntimeException("");
         }
     }
 
     @Override
     public Boolean checkObjectExists(String bucket, String object) {
-        try{
+        try {
             // TO BE SUPPORTED
             return false;
-        }catch (Exception e){
+        } catch (Exception e) {
             throw new RuntimeException("");
         }
     }
@@ -117,7 +117,7 @@ public class MinioClientImpl implements IMinioClient {
                     .object(object)
                     .isObjectExists(true)
                     .build();
-        }catch (Exception e){
+        } catch (Exception e) {
             log.error("downloadObject occurs an error.", e);
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioDownloadObjectResult.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioDownloadObjectResult.java
@@ -1,0 +1,22 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.autotuneservice.minio;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author huangkaifei
+ * @version : MinioDownloadObjectResult.java, v 0.1 2022年11月09日 2:44 AM huangkaifei Exp $
+ */
+@Data
+@Builder
+public class MinioDownloadObjectResult {
+
+    private String bucket;
+    private String object;
+    private boolean isObjectExists;
+    private String message;
+}

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioServerStarter.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioServerStarter.java
@@ -1,0 +1,73 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.autotuneservice.minio;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Embed the minio server
+ *
+ * @author huangkaifei
+ * @version : MinioServerStarter.java, v 0.1 2022年11月09日 1:29 PM huangkaifei Exp $
+ */
+@Slf4j
+@Component
+public class MinioServerStarter {
+
+    @PostConstruct
+    public void startMinioServer() {
+        start();
+    }
+
+    private boolean execCmd(String cmd) {
+        try {
+            Process exec = Runtime.getRuntime().exec(new String[] {"/bin/sh", "-c", cmd});
+            if (exec.waitFor() != 0) {
+                log.error("execCmd={} failed. errorMsg={}", cmd, convert(exec.getErrorStream()));
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            log.error("execCmd={} occurs an error.", cmd, e);
+            return false;
+        }
+    }
+
+    private String convert(InputStream inputStream) throws IOException {
+        return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+    }
+
+    private void start() {
+        if (!execCmd("mkdir /tmp/minio-server")) {
+            return;
+        }
+        log.info("*********start download minio********");
+        String downloadCmd = "curl -o /tmp/minio-server/minio https://dl.min.io/server/minio/release/linux-amd64/minio";
+        if (!execCmd(downloadCmd)) {
+            log.error("download minio file failed.");
+            return;
+        }
+
+        log.info("start chmod /tmp/minio-server/minio......");
+        String chmodCmd = "chmod +x  /tmp/minio-server/minio";
+        if (!execCmd(chmodCmd)) {
+            log.error("chmod /tmp/minio-server/minio failed");
+            return;
+        }
+        log.info("start minio server.....");
+        String startMinioCmd = "/tmp/minio-server/minio server /tmp/minio-db --address :9098 --console-address :9099";
+        if (!execCmd(startMinioCmd)) {
+            log.error("start minio server failed");
+            return;
+        }
+    }
+}

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioServerStarter.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioServerStarter.java
@@ -47,8 +47,8 @@ public class MinioServerStarter {
     }
 
     private void start() {
-        if (!execCmd("mkdir /tmp/minio-server")) {
-            return;
+        if (!execCmd("ls /tmp/minio-server")) {
+            execCmd("mkdir /tmp/minio-server");
         }
         log.info("*********start download minio********");
         String downloadCmd = "curl -o /tmp/minio-server/minio https://dl.min.io/server/minio/release/linux-amd64/minio";
@@ -56,7 +56,6 @@ public class MinioServerStarter {
             log.error("download minio file failed.");
             return;
         }
-
         log.info("start chmod /tmp/minio-server/minio......");
         String chmodCmd = "chmod +x  /tmp/minio-server/minio";
         if (!execCmd(chmodCmd)) {

--- a/src/main/java/com/alipay/autotuneservice/minio/MinioUploadFileResult.java
+++ b/src/main/java/com/alipay/autotuneservice/minio/MinioUploadFileResult.java
@@ -1,0 +1,33 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.autotuneservice.minio;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author huangkaifei
+ * @version : MinioUploadFileResult.java, v 0.1 2022年11月09日 1:33 AM huangkaifei Exp $
+ */
+@Data
+@Builder
+public class MinioUploadFileResult {
+    /**
+     * The unique key to the upload file
+     */
+    private String eTag;
+    /**
+     * The bucket name
+     */
+    private String bucket;
+    /**
+     * The object name in minio
+     */
+    private String object;
+    /**
+     * The result of uploading file
+     */
+    private Boolean success;
+}

--- a/src/test/java/com/alipay/autotuneservice/minio/IMinioClientTest.java
+++ b/src/test/java/com/alipay/autotuneservice/minio/IMinioClientTest.java
@@ -1,0 +1,52 @@
+package com.alipay.autotuneservice.minio;
+
+import io.minio.MinioClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class IMinioClientTest {
+
+    @Autowired
+    private IMinioClient minioClient;
+
+    @Test
+    void getMinioClient() {
+        MinioClient minioClient = this.minioClient.getMinioClient();
+        assertTrue(minioClient!=null);
+    }
+
+    @Test
+    void checkBucketExists() {
+    }
+
+    @Test
+    void checkObjectExists() {
+    }
+
+    @Test
+    void uploadObject() {
+        String filePath = "/tmp/minio/hello.txt";
+        String bucket = "tmaestro";
+        String fileName = "hello.txt";
+
+        MinioUploadFileResult result = minioClient.uploadObject(bucket, filePath, fileName);
+
+        assertTrue(result.getSuccess());
+    }
+
+    @Test
+    void downloadObject() {
+        String downloadFilePath = "/tmp/minio/download/hello.txt";
+        String bucket = "tmaestro";
+        String fileName = "hello.txt";
+
+        MinioDownloadObjectResult result = minioClient.downloadObject(bucket, fileName, downloadFilePath);
+
+        assertTrue(result.isObjectExists());
+
+    }
+}

--- a/tmaestro-lite.yaml
+++ b/tmaestro-lite.yaml
@@ -15,7 +15,7 @@ spec:
         app: tmaestro
     spec:
       containers:
-        - image: tmaestro/202211090322
+        - image: tmaestro/202211091508
           imagePullPolicy: Never
           name: tmaestro-server
           ports:
@@ -50,27 +50,27 @@ spec:
           image:  registry.cn-beijing.aliyuncs.com/saasalpha/tmaster:ats_tmaster_front_202209051751
           ports:
             - containerPort: 80
-        - name: minio-server
-          image: quay.io/minio/minio:latest
-          ports:
-            - containerPort: 9098
-            - containerPort: 9099
-          command:
-            - /bin/bash
-            - -c
-          args:
-            - minio server /data --address :9098 --console-address :9099 # the /data path is for the minio server put uploaded file
-          volumeMounts:
-            - mountPath: /data
-              name: localvolume # Corresponds to the `spec.volumes` Persistent Volume
+#        - name: minio-server
+#          image: quay.io/minio/minio:latest
+#          ports:
+#            - containerPort: 9098
+#            - containerPort: 9099
+#          command:
+#            - /bin/bash
+#            - -c
+#          args:
+#            - minio server /data --address :9098 --console-address :9099 # the /data path is for the minio server put uploaded file
+#          volumeMounts:
+#            - mountPath: /data
+#              name: localvolume # Corresponds to the `spec.volumes` Persistent Volume
       volumes:
         - name: tmaestro
           configMap:
             name: tmaestro-kube-config
-        - name: localvolume
-          hostPath: # MinIO generally recommends using locally-attached volumes
-            path: /mnt/disk1/data # Specify a path to a local drive or volume on the Kubernetes worker node
-            type: DirectoryOrCreate # The path to the last directory must exist
+#        - name: localvolume
+#          hostPath: # MinIO generally recommends using locally-attached volumes
+#            path: /mnt/disk1/data # Specify a path to a local drive or volume on the Kubernetes worker node
+#            type: DirectoryOrCreate # The path to the last directory must exist
 ---
 apiVersion: v1
 kind: Service

--- a/tmaestro-lite.yaml
+++ b/tmaestro-lite.yaml
@@ -15,7 +15,7 @@ spec:
         app: tmaestro
     spec:
       containers:
-        - image: tmaestro/202211021115
+        - image: tmaestro/202211090322
           imagePullPolicy: Never
           name: tmaestro-server
           ports:
@@ -50,10 +50,27 @@ spec:
           image:  registry.cn-beijing.aliyuncs.com/saasalpha/tmaster:ats_tmaster_front_202209051751
           ports:
             - containerPort: 80
+        - name: minio-server
+          image: quay.io/minio/minio:latest
+          ports:
+            - containerPort: 9098
+            - containerPort: 9099
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - minio server /data --address :9098 --console-address :9099 # the /data path is for the minio server put uploaded file
+          volumeMounts:
+            - mountPath: /data
+              name: localvolume # Corresponds to the `spec.volumes` Persistent Volume
       volumes:
         - name: tmaestro
           configMap:
             name: tmaestro-kube-config
+        - name: localvolume
+          hostPath: # MinIO generally recommends using locally-attached volumes
+            path: /mnt/disk1/data # Specify a path to a local drive or volume on the Kubernetes worker node
+            type: DirectoryOrCreate # The path to the last directory must exist
 ---
 apiVersion: v1
 kind: Service
@@ -61,11 +78,10 @@ metadata:
   name: tmaestro
 spec:
   ports:
-    #    nodePort(集群外访问的端口) -> port(service) -> targetPort(POD的容器端口)
-    - port: 9001       # Service的容器端口
+    - port: 9001
       name: http
-      targetPort: 9001  # POD的容器端口
-      nodePort: 30081   # 集群外访问的端口
+      targetPort: 9001
+      nodePort: 30081
       protocol: TCP
     - port: 9000
       name: grpc
@@ -85,6 +101,16 @@ spec:
       name: alog-intelligent-url
       targetPort: 9091
       nodePort: 30085
+    - port: 9099       # Minio console port
+      name: minioconsole
+      targetPort: 9099
+      nodePort: 30086
+      protocol: TCP
+    - port: 9098      # Minio server api port
+      name: minioapi
+      targetPort: 9098
+      nodePort: 30087
+      protocol: TCP
   type: NodePort
   selector:
     app: tmaestro


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/alipay/container-auto-tune/issues/19

# Rationale for this change
To reduce the dependency when user start project locally, So use Minio to replace OSS.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- add Minio Server deploy container
- add Minio client for uploading and downloading object,  please see com.alipay.autotuneservice.minio.IMinioClient
- add Minio client testing, please see com.alipay.autotuneservice.minio.IMinioClientTest 
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Yes, after the changes works, the developers can download gc logs on the fly and do not have the dependency to OSS.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
- step1:  run UT com.alipay.autotuneservice.minio.IMinioClientTest#uploadObject and com.alipay.autotuneservice.minio.IMinioClientTest#downloadObject by updating the filepath
- step2: run make command and deploy locally, you can enter the minio-server container
![image](https://user-images.githubusercontent.com/39024249/200661783-420349e2-a0cd-4816-ab41-6f0dc886a59e.png)

![image](https://user-images.githubusercontent.com/39024249/200662683-34806ede-3300-4e80-9d48-205ce9a8a5c6.png)


- step3: check the upload file from /data/tmaestro path in minio-server container
![image](https://user-images.githubusercontent.com/39024249/200661994-828fc064-e21b-4b40-985b-29070143b664.png)


<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

# Usages:
- users can access to the com.alipay.autotuneservice.minio.IMinioClient to do action they want in minio-server container
